### PR TITLE
Change propType cell overflow to 'auto' instead of scroll

### DIFF
--- a/src/Components/PropTable.js
+++ b/src/Components/PropTable.js
@@ -35,7 +35,7 @@ const styles = {
   propType: {
     ...cell,
     maxWidth: '150px',
-    overflow: 'scroll',
+    overflow: 'auto',
     color: '#2e7d32'
   },
   required: {


### PR DESCRIPTION
As styled with 'scroll', the propType cell shows scrollbars in both directions even if no scrolling is needed. This looks strange, and messes with the formatting of the rest of the table. 'auto' will show the scrollbars only when they're necessary due to the length of the content.

Thanks for this addon -- it's just what I was looking for!