### PR TITLE
Fix dark-mode font colors

### DIFF
--- a/src/Components/Story.js
+++ b/src/Components/Story.js
@@ -3,7 +3,6 @@
 import React, { Component } from 'react';
 import { polyfill } from 'react-lifecycles-compat';
 import PropTypes from 'prop-types';
-import { baseFonts } from '@storybook/components';
 
 const getName = type => type.displayName || type.name;
 
@@ -58,7 +57,6 @@ export const getProps = (propTables, propTablesExclude, children) => {
 
 const stylesheetBase = {
   infoBody: {
-    ...baseFonts,
     fontWeight: 300,
     lineHeight: 1.45,
     fontSize: '15px',


### PR DESCRIPTION
By forcing the base styles into the wrapper, we're preventing changes to the font-color from propagating down. The font-styles will be inherited from `body` by default.

## Before: 
![screen shot 2019-03-07 at 12 04 43 am](https://user-images.githubusercontent.com/13004162/53941316-a2979700-406c-11e9-9f26-9e4e67f8cecf.png)

## After:
> Light mode

![screen shot 2019-03-07 at 12 01 27 am](https://user-images.githubusercontent.com/13004162/53941329-a9260e80-406c-11e9-8f73-9a15bc2b9d54.png)

> Dark mode

![screen shot 2019-03-07 at 12 01 11 am](https://user-images.githubusercontent.com/13004162/53941333-ab886880-406c-11e9-86a6-53453ebd1603.png)

