### PR TITLE
fix: Add missing `HighlightButton` component to `Shape` component

### DIFF
--- a/src/Components/types/Shape.js
+++ b/src/Components/types/Shape.js
@@ -1,13 +1,26 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { HighlightButton } from '@storybook/components';
 import PrettyPropType from './PrettyPropType';
 import PropertyLabel from './PropertyLabel';
 
 import { TypeInfo, getPropTypes } from './proptypes';
 
 const MARGIN_SIZE = 15;
+
+const HighlightButton = props => (
+  <button
+    type="button"
+    {...props}
+    style={{
+      display: 'inline-block',
+      background: 'none',
+      border: '0 none',
+      color: 'gray',
+      cursor: 'pointer'
+    }}
+  />
+);
 
 class Shape extends React.Component {
   constructor(props) {
@@ -24,29 +37,14 @@ class Shape extends React.Component {
     });
   };
 
-  handleMouseEnter = () => {
-    this.setState({ hover: true });
-  };
-
-  handleMouseLeave = () => {
-    this.setState({ hover: false });
-  };
-
   render() {
     const { propType, depth } = this.props;
-    const { hover, minimized } = this.state;
+    const { minimized } = this.state;
 
     const propTypes = getPropTypes(propType);
     return (
       <span>
-        <HighlightButton
-          highlight={hover}
-          onClick={this.handleToggle}
-          onMouseEnter={this.handleMouseEnter}
-          onMouseLeave={this.handleMouseLeave}
-        >
-          {'{'}
-        </HighlightButton>
+        <HighlightButton onClick={this.handleToggle}>{'{'}</HighlightButton>
         <HighlightButton onClick={this.handleToggle}>...</HighlightButton>
         {!minimized &&
           Object.keys(propTypes).map(childProperty => (
@@ -66,14 +64,7 @@ class Shape extends React.Component {
             </div>
           ))}
 
-        <HighlightButton
-          highlight={hover}
-          onClick={this.handleToggle}
-          onMouseEnter={this.handleMouseEnter}
-          onMouseLeave={this.handleMouseLeave}
-        >
-          {'}'}
-        </HighlightButton>
+        <HighlightButton onClick={this.handleToggle}>{'}'}</HighlightButton>
       </span>
     );
   }


### PR DESCRIPTION
This will fix https://github.com/hipstersmoothie/storybook-addon-react-docgen/issues/15 to the point where components that use `PropTypes.shape` will render as expected. This PR does not address issues around functionality of expanding/collapsing shape props which is broken.

Updated code taken from https://github.com/storybooks/storybook/blob/aceb4b6825f2aef2753fcbbcb513cbe5d8b610fc/addons/info/src/components/types/Shape.js