### PR TITLE
Only render story content once, fix storyboook 5.2 knobs compatibility issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,14 +66,15 @@ export const withPropsTable = makeDecorator({
         ? propsTableOptions
         : { ...options, ...propsTableOptions };
 
-    const res = addPropsTable(getStory(context), context, mergedOptions);
+    const content = getStory(context);
+    const res = addPropsTable(content, context, mergedOptions);
 
     channel.emit(
       'storybook/PropsTable/add_PropsTable',
-      ReactDOM.renderToString(<Story {...res}>{getStory(context)}</Story>)
+      ReactDOM.renderToString(<Story {...res}>{content}</Story>)
     );
 
-    return getStory(context);
+    return content;
   }
 });
 


### PR DESCRIPTION
Rendering stories multiple times seems bad + this would break knobs in storybook 5.2
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.2.21-canary.49.443`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
