### PR TITLE
fix: propTablesExclude to work for forwardRef(FC)

### DIFF
--- a/src/Components/Story.js
+++ b/src/Components/Story.js
@@ -42,6 +42,14 @@ export const getProps = (propTables, propTablesExclude, children) => {
     ) {
       return true;
     }
+    
+    if (
+      element.type &&
+      typeof element.type &&
+      element.type.displayName === Component
+    ) {
+      return true;
+    }
 
     return false;
   };


### PR DESCRIPTION
When you use forwardRef with function components, (element.type.name === Component) would not work
We can leverage on displayName to solve this.
![image](https://user-images.githubusercontent.com/1619263/78500688-9ef5a880-7775-11ea-9c52-a1fb46bc6c0e.png)


```
const MyFuncComponent = forwardRef((props, ref) => {
     return (<div>hello</div>);
});
MyFuncComponent.displayName = "MyFuncComponent";
```

With the above change, we should be able to use function components as well 
```
props: {
   propTablesExclude: ['MyFuncComponent']
}
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.2.29-canary.90.965`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
