### PR TITLE
feat: absolute propTypes in excludedPropTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,12 @@ storiesOf('Component', module)
    */
   TableComponent: React.ComponentType,
   /**
-   * Will exclude any respective properties whose name is included in array
+   * Will exclude any respective properties whose name is included in array.
+   * Can also specify absolute propType to exclude (see example below)
+   * Examples: 
+   * excludedPropTypes: ["message"] // propType to exclude
+   * excludedPropTypes: ["MyComponent.message"] // absolute propType
+   * 
    * @default []
    */
   excludedPropTypes: Array<string>,

--- a/src/Components/PropTable.js
+++ b/src/Components/PropTable.js
@@ -52,6 +52,8 @@ const styles = {
   }
 };
 
+const getName = type => type.displayName || type.name;
+
 export const multiLineText = input => {
   if (!input) {
     return input;
@@ -73,13 +75,17 @@ export const multiLineText = input => {
   ));
 };
 
-const determineIncludedPropTypes = (propDefinitions, excludedPropTypes) => {
+const determineIncludedPropTypes = (propDefinitions, excludedPropTypes, type) => {
   if (excludedPropTypes.length === 0) {
     return propDefinitions;
   }
-
+  const name = getName(type);
   return propDefinitions.filter(
-    propDefinition => !excludedPropTypes.includes(propDefinition.property)
+    propDefinition => {
+      const propertyName = propDefinition.property;
+      const propertyNameAbsolute = `${name}.${propertyName}`;
+      return !(excludedPropTypes.includes(propertyName) || excludedPropTypes.includes(propertyNameAbsolute));
+    }
   );
 };
 
@@ -99,7 +105,8 @@ export default function PropTable(props) {
 
   const includedPropDefinitions = determineIncludedPropTypes(
     propDefinitions,
-    excludedPropTypes
+    excludedPropTypes,
+    type
   );
 
   if (includedPropDefinitions.length === 0) {

--- a/src/Components/PropTable.js
+++ b/src/Components/PropTable.js
@@ -79,6 +79,7 @@ const determineIncludedPropTypes = (propDefinitions, excludedPropTypes, type) =>
   if (excludedPropTypes.length === 0) {
     return propDefinitions;
   }
+
   const name = getName(type);
   return propDefinitions.filter(
     propDefinition => {


### PR DESCRIPTION
excludedPropTypes can now support an absolute path for propType.

For example, consider below two components MyComponent & FooComponent.

**MyComponent.tsx**
```
export type MyComponentProps = {
  /** 
   * Value
   */
  value?: string,
  
  /** 
   * Message
   */
  message?: string,
};
const MyComponent: FunctionComponent<MyComponentProps> = (props: MyComponentProps) => {
  return (<div>hello</div>);
};
MyComponent.displayName = "MyComponent";
export default MyComponent;
```

**FooComponent.tsx**
```
export type FooComponentProps = {  
  /** 
   * Message
   */
  message?: string,
};
const FooComponent: FunctionComponent<FooComponentProps> = (props: FooComponentProps) => {
  return (<div>hello foo</div>);
};
FooComponent.displayName = "FooComponent";
export default FooComponent;
```

By excluding `message` prop without absolute path would end up excluding message from altogether from both Components.
```
excludedPropTypes: ["message"] // excludes message from both MyComponent & FooComponent
```

Wheres with an absolute path for excluding it would only exclude the prop for a specific component.
```
excludedPropTypes: ["MyComponent.message"] // excludes message from MyComponent only
```

where MyComponent source would look like below.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.2.29-canary.91.970`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
