### PR TITLE
feat: support propTablesSortOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ storiesOf('Component', module)
    * @default []
    */
   propTables: Array<React.ComponentType>,
+  
+  /**
+   * Define custom sorting order for the components specifying component names in the desired order.
+   * Example:
+   * propTablesSortOrder: ["MyComponent", "FooComponent", "AnotherComponent"]
+   * @default []
+   */
+  propTablesSortOrder: string,
   /**
    * Exclude Components from being shown in Prop Tables section
    * Accepts an array of component classes or functions

--- a/src/Components/Story.js
+++ b/src/Components/Story.js
@@ -8,7 +8,7 @@ const getName = type => type.displayName || type.name;
 const getDescription = type =>
   type.__docgenInfo && type.__docgenInfo.description;
 
-export const getProps = (propTables, propTablesExclude, children) => {
+export const getProps = (propTables, propTablesExclude, propTablesSortOrder, children) => {
   const types = new Map();
 
   if (propTables === null) {
@@ -87,7 +87,31 @@ export const getProps = (propTables, propTablesExclude, children) => {
   extract(children);
 
   const array = [...types.keys()];
-  array.sort((a, b) => getName(a) > getName(b));
+  
+  if (propTablesSortOrder && Array.isArray(propTablesSortOrder) && propTablesSortOrder.length > 0) {
+    array.sort((a, b) => {
+      const nameA = getName(a);
+      const nameB = getName(b);
+      const sA = propTablesSortOrder.indexOf(nameA);
+      const sB = propTablesSortOrder.indexOf(nameB);
+      if (sA === -1 && sB === -1) {
+        return nameA.localeCompare(nameB);
+      }
+      
+      if (sA === -1) {
+        return 1;
+      }
+      
+      if (sB === -1) {
+        return -1;
+      }
+      
+      return sA - sB;
+    });
+  }
+  else {
+    array.sort((a, b) => getName(a).localeCompare(getName(b)));
+  }
 
   return array;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ function addPropsTable(storyFn, context, infoOptions) {
     context,
     components: getProps(
       options.propTables,
+      options.propTablesSortOrder,
       options.propTablesExclude,
       storyFn
     ),
@@ -43,6 +44,7 @@ function addPropsTable(storyFn, context, infoOptions) {
         : s => nestedObjectAssign({}, s, options.styles),
     propTables: options.propTables,
     propTablesExclude: options.propTablesExclude,
+    propTablesSortOrder: options.propTablesSortOrder,
     PropTable: makeTableComponent(options.TableComponent),
     maxPropObjectKeys: options.maxPropObjectKeys,
     maxPropArrayLength: options.maxPropArrayLength,


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.2.31-canary.94.1016`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
