### PR TITLE
positional params error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,8 +34,8 @@ function addPropsTable(storyFn, context, infoOptions) {
     context,
     components: getProps(
       options.propTables,
-      options.propTablesSortOrder,
       options.propTablesExclude,
+      options.propTablesSortOrder,
       storyFn
     ),
     styles:


### PR DESCRIPTION
`options.propTablesSortOrder` is where `options.propTablesExclude` should be in the `getProps` call.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.2.33-canary.99.1251`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
