### PR TITLE
feat: interactive props panel

### DIFF
--- a/src/Components/PropTable.js
+++ b/src/Components/PropTable.js
@@ -170,7 +170,7 @@ PropTable.defaultProps = {
 };
 
 PropTable.propTypes = {
-  type: PropTypes.func,
+  type: PropTypes.object,
   maxPropObjectKeys: PropTypes.number.isRequired,
   maxPropArrayLength: PropTypes.number.isRequired,
   maxPropStringLength: PropTypes.number.isRequired,

--- a/src/Components/Story.js
+++ b/src/Components/Story.js
@@ -3,6 +3,8 @@
 import React, { Component } from 'react';
 import { polyfill } from 'react-lifecycles-compat';
 import PropTypes from 'prop-types';
+import PropTable from './PropTable';
+import makeTableComponent from './makeTableComponent';
 
 const getName = type => type.displayName || type.name || '';
 const getDescription = type =>
@@ -121,7 +123,7 @@ export const getProps = ({ propTables, include, exclude, order, children }) => {
   return array;
 };
 
-const stylesheetBase = {
+export const stylesheetBase = {
   infoBody: {
     fontWeight: 300,
     lineHeight: 1.45,
@@ -148,8 +150,9 @@ class Story extends Component {
   static displayName = 'Story';
 
   static propTypes = {
+    PropTable: PropTypes.func,
     propTables: PropTypes.arrayOf(PropTypes.func),
-    styles: PropTypes.func.isRequired,
+    styles: PropTypes.object.isRequired,
     components: PropTypes.array.isRequired,
     maxPropObjectKeys: PropTypes.number.isRequired,
     maxPropArrayLength: PropTypes.number.isRequired,
@@ -158,21 +161,18 @@ class Story extends Component {
   };
 
   static defaultProps = {
+    PropTable: makeTableComponent(PropTable),
     propTables: null,
     excludedPropTypes: []
   };
 
-  state = {
-    stylesheet: this.props.styles(stylesheetBase)
-  };
-
   _renderInline() {
-    const { stylesheet } = this.state;
+    const { styles } = this.props;
 
     return (
       <div>
-        <div style={stylesheet.infoPage}>
-          <div style={stylesheet.infoBody}>{this._getPropTables()}</div>
+        <div style={styles.infoPage}>
+          <div style={styles.infoBody}>{this._getPropTables()}</div>
         </div>
       </div>
     );
@@ -186,8 +186,7 @@ class Story extends Component {
       maxPropStringLength,
       excludedPropTypes
     } = this.props;
-    let { propTables } = this.props;
-    const { stylesheet } = this.state;
+    let { propTables, styles } = this.props;
 
     if (propTables === null) {
       return null;
@@ -198,10 +197,10 @@ class Story extends Component {
       return (
         // eslint-disable-next-line react/no-array-index-key
         <div key={`${getName(type)}_${i}`}>
-          <h2 style={stylesheet.propTableHead}>
+          <h2 style={styles.propTableHead}>
             &ldquo;{getName(type)}&rdquo; Component
           </h2>
-          {description && <p style={stylesheet.description}>{description}</p>}
+          {description && <p style={styles.description}>{description}</p>}
           <this.props.PropTable
             type={type}
             maxPropObjectKeys={maxPropObjectKeys}
@@ -219,7 +218,7 @@ class Story extends Component {
 
     return (
       <div>
-        <h1 style={stylesheet.h1}>Prop Types</h1>
+        <h1 style={styles.h1}>Prop Types</h1>
         {propTables}
       </div>
     );

--- a/src/Components/Story.js
+++ b/src/Components/Story.js
@@ -186,7 +186,7 @@ class Story extends Component {
       maxPropStringLength,
       excludedPropTypes
     } = this.props;
-    let { propTables, styles } = this.props;
+    let { PropTable, propTables, styles } = this.props;
 
     if (propTables === null) {
       return null;
@@ -201,7 +201,7 @@ class Story extends Component {
             &ldquo;{getName(type)}&rdquo; Component
           </h2>
           {description && <p style={styles.description}>{description}</p>}
-          <this.props.PropTable
+          <PropTable
             type={type}
             maxPropObjectKeys={maxPropObjectKeys}
             maxPropArrayLength={maxPropArrayLength}

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,12 @@ import ReactDOM from 'react-dom/server';
 import nestedObjectAssign from 'nested-object-assign';
 import addons, { makeDecorator } from '@storybook/addons';
 
-import Story, { getProps } from './Components/Story';
+import Story, { getProps, stylesheetBase } from './Components/Story';
 import PropTable from './Components/PropTable';
 import makeTableComponent from './Components/makeTableComponent';
 
 const defaultOptions = {
   propTables: [],
-  TableComponent: PropTable,
   maxPropsIntoLine: 3,
   maxPropObjectKeys: 3,
   maxPropArrayLength: 3,
@@ -38,16 +37,18 @@ function addPropsTable(storyFn, context, infoOptions) {
       exclude: options.propTablesExclude,
       order: options.propTablesSortOrder,
       children: storyFn
-    }),
+    }).map(c => ({ ...c })),
     styles:
       typeof options.styles === 'function'
         ? options.styles
-        : s => nestedObjectAssign({}, s, options.styles),
-    propTables: options.propTables,
+        : nestedObjectAssign({}, stylesheetBase, options.styles),
+    propTables: options.propTables.map(c => ({ ...c })),
     propTablesInclude: options.propTablesInclude,
     propTablesExclude: options.propTablesExclude,
     propTablesSortOrder: options.propTablesSortOrder,
-    PropTable: makeTableComponent(options.TableComponent),
+    ...(options.TableComponent && {
+      PropTable: makeTableComponent(options.TableComponent)
+    }),
     maxPropObjectKeys: options.maxPropObjectKeys,
     maxPropArrayLength: options.maxPropArrayLength,
     maxPropsIntoLine: options.maxPropsIntoLine,
@@ -73,10 +74,15 @@ export const withPropsTable = makeDecorator({
     const content = getStory(context);
     const response = addPropsTable(content, context, mergedOptions);
 
-    channel.emit(
-      'storybook/PropsTable/add_PropsTable',
-      ReactDOM.renderToString(<Story {...response}>{content}</Story>)
-    );
+    const shouldLegacyRender = Boolean(mergedOptions.TableComponent);
+
+    if (shouldLegacyRender) {
+      channel.emit('storybook/PropsTable/add_PropsTable', {
+        legacy: ReactDOM.renderToString(<Story {...response} />)
+      });
+    } else {
+      channel.emit('storybook/PropsTable/add_PropsTable', response);
+    }
 
     return content;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import nestedObjectAssign from 'nested-object-assign';
 import addons, { makeDecorator } from '@storybook/addons';
 
 import Story, { getProps, stylesheetBase } from './Components/Story';
-import PropTable from './Components/PropTable';
 import makeTableComponent from './Components/makeTableComponent';
 
 const defaultOptions = {

--- a/src/register.js
+++ b/src/register.js
@@ -22,6 +22,10 @@ export class PropsTable extends React.Component {
     legacy: PropTypes.string
   };
 
+  static defaultProps = {
+    legacy: false
+  };
+
   state = { text: '' };
 
   componentDidMount() {
@@ -57,9 +61,8 @@ export class PropsTable extends React.Component {
       return legacy;
     }
 
-    return Boolean(active && text) ? (
+    return active && text ? (
       <div
-        // eslint-disable-next-line react/no-danger
         style={{ padding: 10, boxSizing: 'border-box', width: '100%' }}
         className="addon-PropsTable-container"
       >

--- a/src/register.js
+++ b/src/register.js
@@ -26,7 +26,7 @@ export class PropsTable extends React.Component {
     legacy: false
   };
 
-  state = { text: '' };
+  state = { propData: null };
 
   componentDidMount() {
     const { channel, api } = this.props;
@@ -49,24 +49,24 @@ export class PropsTable extends React.Component {
     );
   }
 
-  onAddPropsTable = text => {
-    this.setState({ text });
+  onAddPropsTable = propData => {
+    this.setState({ propData });
   };
 
   render() {
     const { active, legacy } = this.props;
-    const { text } = this.state;
+    const { propData } = this.state;
 
     if (legacy) {
       return legacy;
     }
 
-    return active && text ? (
+    return active && propData ? (
       <div
         style={{ padding: 10, boxSizing: 'border-box', width: '100%' }}
         className="addon-PropsTable-container"
       >
-        <Story {...text} />
+        <Story {...propData} />
       </div>
     ) : null;
   }

--- a/src/register.js
+++ b/src/register.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import addons from '@storybook/addons';
 import { STORY_CHANGED } from '@storybook/core-events';
+import Story from './Components/Story';
 
 export class PropsTable extends React.Component {
   static propTypes = {
@@ -17,7 +18,8 @@ export class PropsTable extends React.Component {
       off: PropTypes.func,
       getQueryParam: PropTypes.func,
       setQueryParams: PropTypes.func
-    }).isRequired
+    }).isRequired,
+    legacy: PropTypes.string
   };
 
   state = { text: '' };
@@ -48,16 +50,21 @@ export class PropsTable extends React.Component {
   };
 
   render() {
-    const { active } = this.props;
+    const { active, legacy } = this.props;
     const { text } = this.state;
 
-    return active ? (
+    if (legacy) {
+      return legacy;
+    }
+
+    return Boolean(active && text) ? (
       <div
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: text }}
         style={{ padding: 10, boxSizing: 'border-box', width: '100%' }}
         className="addon-PropsTable-container"
-      />
+      >
+        <Story {...text} />
+      </div>
     ) : null;
   }
 }

--- a/stories/button.js
+++ b/stories/button.js
@@ -5,7 +5,25 @@ export const Button = props => <button {...props} />;
 
 Button.propTypes = {
   /** A action for the button to take */
-  action: PropTypes.string
+  action: PropTypes.string,
+  /* A made-up property to test minimizing/expanding enum list */
+  label: PropTypes.oneOf([
+    'a',
+    'b',
+    'c',
+    'd',
+    'e',
+    'f',
+    'g',
+    'h',
+    'i',
+    'j',
+    'k',
+    'l',
+    'm',
+    'n',
+    'o'
+  ])
 };
 
 Button.defaultProps = {

--- a/stories/button.js
+++ b/stories/button.js
@@ -6,7 +6,7 @@ export const Button = props => <button {...props} />;
 Button.propTypes = {
   /** A action for the button to take */
   action: PropTypes.string,
-  /* A made-up property to test minimizing/expanding enum list */
+  /** A made-up property to test minimizing/expanding enum list */
   label: PropTypes.oneOf([
     'a',
     'b',


### PR DESCRIPTION
## Feature

This PR adds functionality to make the Props panel interactive. (Prior to this PR, clicking the ellipsis button for enums had no effect).

<img width="1392" alt="Screen Shot 2020-06-08 at 10 52 19 PM" src="https://user-images.githubusercontent.com/1571918/84111052-ec430000-a9da-11ea-8142-88771370c882.png">

<img width="1392" alt="Screen Shot 2020-06-08 at 10 52 31 PM" src="https://user-images.githubusercontent.com/1571918/84111057-ef3df080-a9da-11ea-9808-6829961ce214.png">

## Context

Previously, the Props panel area was rendered as a string, and passed to the panel via an event emitters:

https://github.com/hipstersmoothie/storybook-addon-react-docgen/blob/0ed4acef661ac50ea7b2e2b28a90cb4ffe449ae6/src/index.js#L76-L79

This serialization of the React node loses the interactivity: click handlers, etc will not function when communicating this way.

The solution is to pass the data needed over the event emitter, and then render 'on the other side'. There are some caveats, though. Functions don't go through the event emitter very well. Now that everything needs to be serialized, it would be good to check `propTables`, `propTablesInclude`, and `propTablesExclude` still work correctly. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.36-canary.104.1362.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install storybook-addon-react-docgen@1.2.36-canary.104.1362.0
  # or 
  yarn add storybook-addon-react-docgen@1.2.36-canary.104.1362.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
