### PR TITLE
chore: filter React Fragments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,9 @@ function addPropsTable(storyFn, context, infoOptions) {
       exclude: options.propTablesExclude,
       order: options.propTablesSortOrder,
       children: storyFn
-    }).map(c => ({ ...c })),
+    })
+      .map(c => ({ ...c }))
+      .filter(c => c && Object.keys(c).length),
     styles:
       typeof options.styles === 'function'
         ? options.styles

--- a/stories/1-Button.stories.js
+++ b/stories/1-Button.stories.js
@@ -19,3 +19,11 @@ export const Emoji = () => (
     </span>
   </Button>
 );
+
+export const Fragment = () => {
+  return (
+    <>
+      <Button onClick={action('clicked')}>Button in Fragment</Button>
+    </>
+  );
+};


### PR DESCRIPTION
Sample code:

```tsx
export const Fragment = () => {
  return (
    <>
      <Button onClick={action('clicked')}>Button in Fragment</Button>
    </>
  );
};
```

Before:
![Screen Shot 2020-06-09 at 4 37 23 PM](https://user-images.githubusercontent.com/1571918/84211480-4b068900-aa70-11ea-923f-f24c88a15d8c.png)

After:
![Screen Shot 2020-06-09 at 4 39 28 PM](https://user-images.githubusercontent.com/1571918/84211492-4f32a680-aa70-11ea-97b5-5b85a3738c68.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.38-canary.106.1391.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install storybook-addon-react-docgen@1.2.38-canary.106.1391.0
  # or 
  yarn add storybook-addon-react-docgen@1.2.38-canary.106.1391.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
