### PR TITLE
Change type checking of object to use Object.is

### DIFF
--- a/src/Components/Story.tsx
+++ b/src/Components/Story.tsx
@@ -94,7 +94,7 @@ export const getProps = ({
         const values = Array.isArray(value) ? value : [value];
 
         values.forEach((v: any) => {
-          if (typeof v === 'object' && v.type) {
+          if (Object.is(v) && v.type) {
             extract(v);
           }
         });


### PR DESCRIPTION
When v === null , `typeof v === 'object'` was returning true.  And the subsequent check for `v.type` was throwing an error.   An example of this is when a prop is something like [null, null, null, 'display'] which is very common when using theme-ui